### PR TITLE
Bump to arcdps+imgui 1.92.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,7 +66,7 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 [[package]]
 name = "arc_util"
 version = "0.11.5"
-source = "git+https://github.com/cheahjs/arcdps-utils?branch=bump-imgui-1.92.7#32cd2dfceff7c7a8461197dbd2561e60f74206d9"
+source = "git+https://github.com/cheahjs/arcdps-utils?branch=bump-imgui-1.92.7#7f9f121bdd0fa7c704d920d0461eb060dfc186b3"
 dependencies = [
  "arcdps",
  "chrono",
@@ -79,7 +79,7 @@ dependencies = [
 [[package]]
 name = "arcdps"
 version = "0.22.0"
-source = "git+https://github.com/cheahjs/Zerthox-arcdps-bindings?branch=bump-imgui-1.92.7#50d74c23dfadf0b93ed9a029622178f4dc6d0506"
+source = "git+https://github.com/cheahjs/Zerthox-arcdps-bindings?branch=bump-imgui-1.92.7#8018ea90954ebbb5f2abb82916d23004d2b547d3"
 dependencies = [
  "arcdps-imgui",
  "arcdps_codegen",
@@ -124,7 +124,7 @@ dependencies = [
 [[package]]
 name = "arcdps-imgui"
 version = "0.13.0"
-source = "git+https://github.com/cheahjs/imgui-rs?branch=arcdps-from-upstream#36a2fefa5def3f07309a179a71d196d0c0840ed8"
+source = "git+https://github.com/cheahjs/imgui-rs?branch=arcdps-from-upstream#29dcca7bd146be068bb94737ce410bba4f3af90a"
 dependencies = [
  "arcdps-imgui-sys",
  "bitflags 1.3.2",
@@ -136,7 +136,7 @@ dependencies = [
 [[package]]
 name = "arcdps-imgui-sys"
 version = "0.13.0"
-source = "git+https://github.com/cheahjs/imgui-rs?branch=arcdps-from-upstream#36a2fefa5def3f07309a179a71d196d0c0840ed8"
+source = "git+https://github.com/cheahjs/imgui-rs?branch=arcdps-from-upstream#29dcca7bd146be068bb94737ce410bba4f3af90a"
 dependencies = [
  "cc",
  "cfg-if",
@@ -146,7 +146,7 @@ dependencies = [
 [[package]]
 name = "arcdps_codegen"
 version = "0.12.1"
-source = "git+https://github.com/cheahjs/Zerthox-arcdps-bindings?branch=bump-imgui-1.92.7#50d74c23dfadf0b93ed9a029622178f4dc6d0506"
+source = "git+https://github.com/cheahjs/Zerthox-arcdps-bindings?branch=bump-imgui-1.92.7#8018ea90954ebbb5f2abb82916d23004d2b547d3"
 dependencies = [
  "cfg-if",
  "paste",
@@ -490,7 +490,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 [[package]]
 name = "evtc"
 version = "0.14.0"
-source = "git+https://github.com/cheahjs/Zerthox-arcdps-bindings?branch=bump-imgui-1.92.7#50d74c23dfadf0b93ed9a029622178f4dc6d0506"
+source = "git+https://github.com/cheahjs/Zerthox-arcdps-bindings?branch=bump-imgui-1.92.7#8018ea90954ebbb5f2abb82916d23004d2b547d3"
 dependencies = [
  "bitflags 2.10.0",
  "memoffset",
@@ -602,7 +602,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.59.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,7 +79,7 @@ dependencies = [
 [[package]]
 name = "arcdps"
 version = "0.22.0"
-source = "git+https://github.com/cheahjs/Zerthox-arcdps-bindings?branch=bump-imgui-1.92.7#8018ea90954ebbb5f2abb82916d23004d2b547d3"
+source = "git+https://github.com/cheahjs/Zerthox-arcdps-bindings?branch=bump-imgui-1.92.7#9cbf6a65a8cb20512e8e711eeb4f92203dc22882"
 dependencies = [
  "arcdps-imgui",
  "arcdps_codegen",
@@ -124,7 +124,7 @@ dependencies = [
 [[package]]
 name = "arcdps-imgui"
 version = "0.13.0"
-source = "git+https://github.com/cheahjs/imgui-rs?branch=arcdps-from-upstream#29dcca7bd146be068bb94737ce410bba4f3af90a"
+source = "git+https://github.com/cheahjs/imgui-rs?branch=arcdps-from-upstream#5727ebfa581b6870d7060e724dad154b05e23c9d"
 dependencies = [
  "arcdps-imgui-sys",
  "bitflags 1.3.2",
@@ -136,7 +136,7 @@ dependencies = [
 [[package]]
 name = "arcdps-imgui-sys"
 version = "0.13.0"
-source = "git+https://github.com/cheahjs/imgui-rs?branch=arcdps-from-upstream#29dcca7bd146be068bb94737ce410bba4f3af90a"
+source = "git+https://github.com/cheahjs/imgui-rs?branch=arcdps-from-upstream#5727ebfa581b6870d7060e724dad154b05e23c9d"
 dependencies = [
  "cc",
  "cfg-if",
@@ -146,7 +146,7 @@ dependencies = [
 [[package]]
 name = "arcdps_codegen"
 version = "0.12.1"
-source = "git+https://github.com/cheahjs/Zerthox-arcdps-bindings?branch=bump-imgui-1.92.7#8018ea90954ebbb5f2abb82916d23004d2b547d3"
+source = "git+https://github.com/cheahjs/Zerthox-arcdps-bindings?branch=bump-imgui-1.92.7#9cbf6a65a8cb20512e8e711eeb4f92203dc22882"
 dependencies = [
  "cfg-if",
  "paste",
@@ -490,7 +490,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 [[package]]
 name = "evtc"
 version = "0.14.0"
-source = "git+https://github.com/cheahjs/Zerthox-arcdps-bindings?branch=bump-imgui-1.92.7#8018ea90954ebbb5f2abb82916d23004d2b547d3"
+source = "git+https://github.com/cheahjs/Zerthox-arcdps-bindings?branch=bump-imgui-1.92.7#9cbf6a65a8cb20512e8e711eeb4f92203dc22882"
 dependencies = [
  "bitflags 2.10.0",
  "memoffset",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,7 +66,7 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 [[package]]
 name = "arc_util"
 version = "0.11.5"
-source = "git+https://github.com/zerthox/arcdps-utils#915ff307195fbd9203814e318a9d96929d44359d"
+source = "git+https://github.com/cheahjs/arcdps-utils?branch=bump-imgui-1.92.7#32cd2dfceff7c7a8461197dbd2561e60f74206d9"
 dependencies = [
  "arcdps",
  "chrono",
@@ -79,7 +79,7 @@ dependencies = [
 [[package]]
 name = "arcdps"
 version = "0.22.0"
-source = "git+https://github.com/zerthox/arcdps-rs#9deb6990b9c9c837983e2e44b75d996b799afd02"
+source = "git+https://github.com/cheahjs/Zerthox-arcdps-bindings?branch=bump-imgui-1.92.7#0785b2a5bfd93a8fbc6e3ba22339470ee44e5298"
 dependencies = [
  "arcdps-imgui",
  "arcdps_codegen",
@@ -123,29 +123,30 @@ dependencies = [
 
 [[package]]
 name = "arcdps-imgui"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12f578f5194d5eb98de932684b4d2cdd1dcb8efdb97c2c0b2f57f79d262b866c"
+version = "0.13.0"
+source = "git+https://github.com/cheahjs/imgui-rs?branch=arcdps-from-upstream#6494238f7e6e111dc3e89150883f7b382c0dca86"
 dependencies = [
  "arcdps-imgui-sys",
  "bitflags 1.3.2",
- "parking_lot 0.11.2",
+ "cfg-if",
+ "mint",
+ "parking_lot",
 ]
 
 [[package]]
 name = "arcdps-imgui-sys"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a739ce8c804e41f71f363d17f002e91c263af34cdbdc835c5d0513982ca09af8"
+version = "0.13.0"
+source = "git+https://github.com/cheahjs/imgui-rs?branch=arcdps-from-upstream#6494238f7e6e111dc3e89150883f7b382c0dca86"
 dependencies = [
  "cc",
- "chlorine",
+ "cfg-if",
+ "mint",
 ]
 
 [[package]]
 name = "arcdps_codegen"
 version = "0.12.1"
-source = "git+https://github.com/zerthox/arcdps-rs#9deb6990b9c9c837983e2e44b75d996b799afd02"
+source = "git+https://github.com/cheahjs/Zerthox-arcdps-bindings?branch=bump-imgui-1.92.7#0785b2a5bfd93a8fbc6e3ba22339470ee44e5298"
 dependencies = [
  "cfg-if",
  "paste",
@@ -270,12 +271,6 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
-
-[[package]]
-name = "chlorine"
-version = "1.0.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c00d31b1d19317b4777ec879192d3745bd97d05262b4b19cb1dda284b9d22f19"
 
 [[package]]
 name = "chrono"
@@ -495,7 +490,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 [[package]]
 name = "evtc"
 version = "0.14.0"
-source = "git+https://github.com/zerthox/arcdps-rs#9deb6990b9c9c837983e2e44b75d996b799afd02"
+source = "git+https://github.com/cheahjs/Zerthox-arcdps-bindings?branch=bump-imgui-1.92.7#0785b2a5bfd93a8fbc6e3ba22339470ee44e5298"
 dependencies = [
  "bitflags 2.10.0",
  "memoffset",
@@ -633,15 +628,6 @@ checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -811,6 +797,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mint"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e53debba6bda7a793e5f99b8dacf19e626084f525f7829104ba9898f367d85ff"
+
+[[package]]
 name = "ndk"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -857,7 +849,7 @@ dependencies = [
  "ndk-macro",
  "ndk-sys 0.4.1+23.1.7779620",
  "once_cell",
- "parking_lot 0.12.5",
+ "parking_lot",
 ]
 
 [[package]]
@@ -1111,37 +1103,12 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core 0.8.6",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.12",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
-dependencies = [
- "cfg-if",
- "instant",
- "libc",
- "redox_syscall 0.2.16",
- "smallvec",
- "winapi",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1152,7 +1119,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link 0.2.1",
 ]
@@ -1238,7 +1205,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51de85fb3fb6524929c8a2eb85e6b6d363de4e8c48f9e2c2eac4944abc181c93"
 dependencies = [
  "log",
- "parking_lot 0.12.5",
+ "parking_lot",
  "scheduled-thread-pool",
 ]
 
@@ -1287,15 +1254,6 @@ name = "raw-window-handle"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9"
-
-[[package]]
-name = "redox_syscall"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags 1.3.2",
-]
 
 [[package]]
 name = "redox_syscall"
@@ -1405,7 +1363,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
 dependencies = [
- "parking_lot 0.12.5",
+ "parking_lot",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,7 +79,7 @@ dependencies = [
 [[package]]
 name = "arcdps"
 version = "0.22.0"
-source = "git+https://github.com/cheahjs/Zerthox-arcdps-bindings?branch=bump-imgui-1.92.7#0785b2a5bfd93a8fbc6e3ba22339470ee44e5298"
+source = "git+https://github.com/cheahjs/Zerthox-arcdps-bindings?branch=bump-imgui-1.92.7#50d74c23dfadf0b93ed9a029622178f4dc6d0506"
 dependencies = [
  "arcdps-imgui",
  "arcdps_codegen",
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "arcdps-chat-log"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "arc_util",
@@ -124,7 +124,7 @@ dependencies = [
 [[package]]
 name = "arcdps-imgui"
 version = "0.13.0"
-source = "git+https://github.com/cheahjs/imgui-rs?branch=arcdps-from-upstream#6494238f7e6e111dc3e89150883f7b382c0dca86"
+source = "git+https://github.com/cheahjs/imgui-rs?branch=arcdps-from-upstream#36a2fefa5def3f07309a179a71d196d0c0840ed8"
 dependencies = [
  "arcdps-imgui-sys",
  "bitflags 1.3.2",
@@ -136,7 +136,7 @@ dependencies = [
 [[package]]
 name = "arcdps-imgui-sys"
 version = "0.13.0"
-source = "git+https://github.com/cheahjs/imgui-rs?branch=arcdps-from-upstream#6494238f7e6e111dc3e89150883f7b382c0dca86"
+source = "git+https://github.com/cheahjs/imgui-rs?branch=arcdps-from-upstream#36a2fefa5def3f07309a179a71d196d0c0840ed8"
 dependencies = [
  "cc",
  "cfg-if",
@@ -146,7 +146,7 @@ dependencies = [
 [[package]]
 name = "arcdps_codegen"
 version = "0.12.1"
-source = "git+https://github.com/cheahjs/Zerthox-arcdps-bindings?branch=bump-imgui-1.92.7#0785b2a5bfd93a8fbc6e3ba22339470ee44e5298"
+source = "git+https://github.com/cheahjs/Zerthox-arcdps-bindings?branch=bump-imgui-1.92.7#50d74c23dfadf0b93ed9a029622178f4dc6d0506"
 dependencies = [
  "cfg-if",
  "paste",
@@ -490,7 +490,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 [[package]]
 name = "evtc"
 version = "0.14.0"
-source = "git+https://github.com/cheahjs/Zerthox-arcdps-bindings?branch=bump-imgui-1.92.7#0785b2a5bfd93a8fbc6e3ba22339470ee44e5298"
+source = "git+https://github.com/cheahjs/Zerthox-arcdps-bindings?branch=bump-imgui-1.92.7#50d74c23dfadf0b93ed9a029622178f4dc6d0506"
 dependencies = [
  "bitflags 2.10.0",
  "memoffset",
@@ -602,7 +602,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.59.0",
 ]
 
 [[package]]
@@ -859,7 +859,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0df7ac00c4672f9d5aece54ee3347520b7e20f158656c7db2e6de01902eb7a6c"
 dependencies = [
  "darling",
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -968,7 +968,7 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -980,7 +980,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
- "proc-macro-crate 3.4.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.111",
@@ -1162,16 +1162,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
  "once_cell",
- "toml_edit 0.19.15",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
-dependencies = [
- "toml_edit 0.23.10+spec-1.0.0",
+ "toml_edit",
 ]
 
 [[package]]
@@ -1739,44 +1730,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 
 [[package]]
-name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
 name = "toml_edit"
 version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap",
- "toml_datetime 0.6.11",
- "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.23.10+spec-1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
-dependencies = [
- "indexmap",
- "toml_datetime 0.7.5+spec-1.1.0",
- "toml_parser",
- "winnow 0.7.14",
-]
-
-[[package]]
-name = "toml_parser"
-version = "1.0.6+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
-dependencies = [
- "winnow 0.7.14",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -2365,15 +2326,6 @@ name = "winnow"
 version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
-version = "0.7.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arcdps-chat-log"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 build = "build.rs"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ crate-type = ["cdylib"]
 
 [dependencies]
 anyhow = "1.0"
-arc_util = { git = "https://github.com/zerthox/arcdps-utils", features = ["settings", "log"] }
-arcdps = { git = "https://github.com/zerthox/arcdps-rs", features = ["extras", "log", "serde", "strum"] }
+arc_util = { git = "https://github.com/cheahjs/arcdps-utils", branch = "bump-imgui-1.92.7", features = ["settings", "log"] }
+arcdps = { git = "https://github.com/cheahjs/Zerthox-arcdps-bindings", branch = "bump-imgui-1.92.7", features = ["extras", "log", "serde", "strum"] }
 backtrace = "0.3"
 bitflags = "2.10"
 chrono = { version = "0.4", features = ["serde"] }
@@ -30,7 +30,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 simple-error = "0.3"
 tts = { git = "https://github.com/cheahjs/tts-rs", branch = "master" }
-winapi = { version = "0.3", features = ["consoleapi", "dbghelp", "memoryapi", "psapi", "handleapi"] }
+winapi = { version = "0.3", features = ["consoleapi", "dbghelp", "memoryapi", "psapi", "handleapi", "processthreadsapi"] }
 windows = { version = "0.59", features = ["System"] }
 
 [build-dependencies]
@@ -39,3 +39,4 @@ winres = "0.1"
 [profile.release-with-debug]
 inherits = "release"
 debug = true
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,11 +108,55 @@ fn init() -> Result<(), Option<String>> {
     debug!("arc init");
     panic_handler::install_panic_handler();
 
+    check_imgui_version();
+
     PLUGIN
         .lock()
         .unwrap()
         .load()
         .map_err(|e| Some(e.to_string()))
+}
+
+fn check_imgui_version() {
+    use arcdps::imgui::sys;
+    use std::ffi::CStr;
+
+    // SAFETY: igGetVersion returns a pointer to a static null-terminated C string
+    // baked into the imgui library; it's valid for the lifetime of the process.
+    let version = unsafe {
+        let ptr = sys::igGetVersion();
+        if ptr.is_null() {
+            "<null>".to_string()
+        } else {
+            CStr::from_ptr(ptr).to_string_lossy().into_owned()
+        }
+    };
+
+    // SAFETY: FFI call into imgui. Passing the version string returned by igGetVersion
+    // together with the struct sizes as known to this binding. If the host arcdps
+    // was built against a different imgui, this will return false (and on some builds
+    // may assert), letting us detect layout drift.
+    let ok = unsafe {
+        let ptr = sys::igGetVersion();
+        sys::igDebugCheckVersionAndDataLayout(
+            ptr,
+            std::mem::size_of::<sys::ImGuiIO>(),
+            std::mem::size_of::<sys::ImGuiStyle>(),
+            std::mem::size_of::<sys::ImVec2>(),
+            std::mem::size_of::<sys::ImVec4>(),
+            std::mem::size_of::<sys::ImDrawVert>(),
+            std::mem::size_of::<sys::ImDrawIdx>(),
+        )
+    };
+
+    if ok {
+        info!("imgui version check passed (version: {})", version);
+    } else {
+        error!(
+            "imgui version/layout check failed (version: {}); possible ABI mismatch with arcdps host",
+            version
+        );
+    }
 }
 
 fn release() {

--- a/src/logui/buffer.rs
+++ b/src/logui/buffer.rs
@@ -131,10 +131,9 @@ impl LogPart {
     }
 
     pub fn get_text(&self, display_hover: bool) -> String {
-        if display_hover || self.hover.is_none() {
-            self.text.clone()
-        } else {
-            format!("{} ({})", self.text, self.hover.as_ref().unwrap())
+        match &self.hover {
+            Some(hover) if !display_hover => format!("{} ({})", self.text, hover),
+            _ => self.text.clone(),
         }
     }
 

--- a/src/logui/buffer.rs
+++ b/src/logui/buffer.rs
@@ -5,8 +5,8 @@ use arcdps::{
     extras::message::{ChannelType, SquadMessageFlags, SquadMessageOwned},
     imgui::{sys, StyleColor},
 };
-use core::ffi::c_char;
 use chrono::Local;
+use core::ffi::c_char;
 
 use super::settings::{ColorSettings, FilterSettings};
 
@@ -68,10 +68,14 @@ impl LogPart {
             let start = s.as_ptr();
             let end = start.add(s.len());
             let font = sys::igGetFont();
-            let scale = ui.io().font_global_scale;
+            // imgui 1.92 reworked this API: the first argument is now the font size in
+            // pixels, not a scale factor. Passing a scale (~1.0) causes imgui to bake a
+            // 1-pixel font and load glyphs on demand for every character on every
+            // frame, which hangs the game when the log has content.
+            let font_size = sys::igGetFontSize();
             let end_line = sys::ImFont_CalcWordWrapPosition(
                 font,
-                scale,
+                font_size,
                 start as *const c_char,
                 end as *const c_char,
                 width_left,

--- a/src/logui/buffer.rs
+++ b/src/logui/buffer.rs
@@ -69,7 +69,6 @@ impl LogPart {
             let end = start.add(s.len());
             let font = sys::igGetFont();
             let scale = ui.io().font_global_scale;
-            // imgui 1.92 renamed `ImFont_CalcWordWrapPositionA` to drop the `A` suffix.
             let end_line = sys::ImFont_CalcWordWrapPosition(
                 font,
                 scale,

--- a/src/logui/buffer.rs
+++ b/src/logui/buffer.rs
@@ -3,11 +3,9 @@ use std::collections::VecDeque;
 use arc_util::ui::{render::item_context_menu, Ui};
 use arcdps::{
     extras::message::{ChannelType, SquadMessageFlags, SquadMessageOwned},
-    imgui::{
-        sys::{self, cty::c_char},
-        StyleColor,
-    },
+    imgui::{sys, StyleColor},
 };
+use core::ffi::c_char;
 use chrono::Local;
 
 use super::settings::{ColorSettings, FilterSettings};
@@ -71,7 +69,8 @@ impl LogPart {
             let end = start.add(s.len());
             let font = sys::igGetFont();
             let scale = ui.io().font_global_scale;
-            let end_line = sys::ImFont_CalcWordWrapPositionA(
+            // imgui 1.92 renamed `ImFont_CalcWordWrapPositionA` to drop the `A` suffix.
+            let end_line = sys::ImFont_CalcWordWrapPosition(
                 font,
                 scale,
                 start as *const c_char,

--- a/src/logui/ui.rs
+++ b/src/logui/ui.rs
@@ -144,7 +144,11 @@ impl Component<&Tracker> for LogUi {
                 ui.same_line_with_spacing(0.0, 0.0);
             }
 
-            if let Some(_child) = ui.child_window("chat_log").child_flags(ChildFlags::BORDERS).begin() {
+            if let Some(_child) = ui
+                .child_window("chat_log")
+                .child_flags(ChildFlags::BORDERS)
+                .begin()
+            {
                 self.buffer
                     .buffer
                     .iter()

--- a/src/logui/ui.rs
+++ b/src/logui/ui.rs
@@ -7,7 +7,7 @@ use std::{
 use arc_util::ui::{render, Component, Ui, Windowable};
 use arcdps::{
     exports::{self, CoreColor},
-    imgui::{sys, StyleColor, StyleVar},
+    imgui::{sys, ChildFlags, StyleColor, StyleVar},
 };
 use log::error;
 
@@ -82,7 +82,7 @@ impl Component<&Tracker> for LogUi {
                 if let Some(_child) = ui
                     .child_window("chat_log_names")
                     .horizontal_scrollbar(true)
-                    .border(true)
+                    .child_flags(ChildFlags::BORDERS)
                     .size([self.ui_props.account_width, 0.0])
                     .begin()
                 {
@@ -144,7 +144,7 @@ impl Component<&Tracker> for LogUi {
                 ui.same_line_with_spacing(0.0, 0.0);
             }
 
-            if let Some(_child) = ui.child_window("chat_log").border(true).begin() {
+            if let Some(_child) = ui.child_window("chat_log").child_flags(ChildFlags::BORDERS).begin() {
                 self.buffer
                     .buffer
                     .iter()

--- a/src/logui/ui.rs
+++ b/src/logui/ui.rs
@@ -7,7 +7,7 @@ use std::{
 use arc_util::ui::{render, Component, Ui, Windowable};
 use arcdps::{
     exports::{self, CoreColor},
-    imgui::{sys, ChildWindow, ColorEdit, Selectable, StyleColor, StyleVar},
+    imgui::{sys, StyleColor, StyleVar},
 };
 use log::error;
 
@@ -77,19 +77,20 @@ impl Component<&Tracker> for LogUi {
                 .build();
         }
 
-        if let Some(_child) = ChildWindow::new("chat_log_child_window").begin(ui) {
+        if let Some(_child) = ui.child_window("chat_log_child_window").begin() {
             if self.settings.show_seen_users {
-                if let Some(_child) = ChildWindow::new("chat_log_names")
+                if let Some(_child) = ui
+                    .child_window("chat_log_names")
                     .horizontal_scrollbar(true)
                     .border(true)
                     .size([self.ui_props.account_width, 0.0])
-                    .begin(ui)
+                    .begin()
                 {
                     ui.text("Seen Users");
                     ui.set_next_item_width(-ui.calc_text_size("Filter")[0] - 5.0);
                     ui.input_text("Filter", &mut self.ui_props.account_filter)
                         .build();
-                    if let Some(_child) = ChildWindow::new("chat_log_names_child").begin(ui) {
+                    if let Some(_child) = ui.child_window("chat_log_names_child").begin() {
                         ui.text_disabled("Tracked");
                         tracker
                             .seen_users
@@ -143,7 +144,7 @@ impl Component<&Tracker> for LogUi {
                 ui.same_line_with_spacing(0.0, 0.0);
             }
 
-            if let Some(_child) = ChildWindow::new("chat_log").border(true).begin(ui) {
+            if let Some(_child) = ui.child_window("chat_log").border(true).begin() {
                 self.buffer
                     .buffer
                     .iter()
@@ -209,7 +210,7 @@ impl LogUi {
             } else {
                 None
             };
-            if Selectable::new(label).build(ui) {
+            if ui.selectable(label) {
                 *text_filter = account_name.to_string();
             }
         }
@@ -248,10 +249,7 @@ impl LogUi {
                         .unwrap_or([1.0, 1.0, 1.0, 1.0]);
                     let white: [f32; 3] = [white[0], white[1], white[2]];
                     let mut note_color = note.color.map_or(white, |color| color);
-                    if ColorEdit::new("Highlight color", &mut note_color)
-                        .alpha(false)
-                        .build(ui)
-                    {
+                    if ui.color_edit3("Highlight color", &mut note_color) {
                         let new_note_color = if note_color != white {
                             Some(note_color)
                         } else {

--- a/src/plugin/settings.rs
+++ b/src/plugin/settings.rs
@@ -327,9 +327,7 @@ impl Plugin {
                 }
 
                 ui.set_next_item_width(input_width);
-                if ui
-                    .slider("TTS volume", 0, 100, &mut self.tts.settings.volume)
-                {
+                if ui.slider("TTS volume", 0, 100, &mut self.tts.settings.volume) {
                     let _ = self.tts.update_settings();
                 }
                 ui.set_next_item_width(input_width);

--- a/src/plugin/settings.rs
+++ b/src/plugin/settings.rs
@@ -2,10 +2,7 @@ use arc_util::ui::{
     render::{self},
     Hideable, Ui,
 };
-use arcdps::{
-    exports::{self, CoreColor},
-    imgui::{Selectable, Slider},
-};
+use arcdps::exports::{self, CoreColor};
 use log::error;
 
 use crate::tts::TextToSpeech;
@@ -165,9 +162,10 @@ impl Plugin {
                     if let Some(_combo) = ui.begin_combo("Output device", current_device) {
                         let is_default_selected =
                             self.notifications.settings.audio_device.is_none();
-                        if Selectable::new("System Default")
+                        if ui
+                            .selectable_config("System Default")
                             .selected(is_default_selected)
-                            .build(ui)
+                            .build()
                         {
                             self.notifications.settings.audio_device = None;
                             crate::AUDIO_PLAYER.lock().unwrap().set_device(None);
@@ -181,7 +179,7 @@ impl Plugin {
                                 .as_ref()
                                 .map(|d| d == device)
                                 .unwrap_or(false);
-                            if Selectable::new(device).selected(is_selected).build(ui) {
+                            if ui.selectable_config(device).selected(is_selected).build() {
                                 self.notifications.settings.audio_device = Some(device.clone());
                                 crate::AUDIO_PLAYER
                                     .lock()
@@ -193,7 +191,7 @@ impl Plugin {
                         ui.separator();
                         if refreshing_devices {
                             ui.text("Refreshing...");
-                        } else if Selectable::new("Refresh devices").build(ui) {
+                        } else if ui.selectable("Refresh devices") {
                             drop(audio_devices_guard);
                             self.ui_state.refresh_audio_devices();
                         }
@@ -218,8 +216,12 @@ impl Plugin {
                 );
 
                 ui.set_next_item_width(input_width);
-                Slider::new("Ping volume", 0, 100)
-                    .build(ui, &mut self.notifications.settings.ping_volume);
+                ui.slider(
+                    "Ping volume",
+                    0,
+                    100,
+                    &mut self.notifications.settings.ping_volume,
+                );
 
                 ui.input_text(
                     "Ping sound path (blank for default)",
@@ -307,9 +309,10 @@ impl Plugin {
                     ) {
                         for (i, voice) in voices.iter().enumerate() {
                             let is_selected = i == cur_pos;
-                            if Selectable::new(TextToSpeech::get_display_name_for_voice(voice))
+                            if ui
+                                .selectable_config(TextToSpeech::get_display_name_for_voice(voice))
                                 .selected(is_selected)
-                                .build(ui)
+                                .build()
                             {
                                 new_voice_id = voice.id().clone();
                             }
@@ -324,33 +327,36 @@ impl Plugin {
                 }
 
                 ui.set_next_item_width(input_width);
-                if Slider::new("TTS volume", 0, 100).build(ui, &mut self.tts.settings.volume) {
+                if ui
+                    .slider("TTS volume", 0, 100, &mut self.tts.settings.volume)
+                {
                     let _ = self.tts.update_settings();
                 }
                 ui.set_next_item_width(input_width);
-                if Slider::new(
+                if ui.slider(
                     "TTS rate",
                     TextToSpeech::min_rate(),
                     TextToSpeech::max_rate(),
-                )
-                .build(ui, &mut self.tts.settings.rate)
-                {
+                    &mut self.tts.settings.rate,
+                ) {
                     let _ = self.tts.update_settings();
                 }
                 ui.set_next_item_width(input_width);
-                if Slider::new(
+                if ui.slider(
                     "TTS pitch",
                     TextToSpeech::min_pitch(),
                     TextToSpeech::max_pitch(),
-                )
-                .build(ui, &mut self.tts.settings.pitch)
-                {
+                    &mut self.tts.settings.pitch,
+                ) {
                     let _ = self.tts.update_settings();
                 }
                 ui.set_next_item_width(input_width);
-                if Slider::new("TTS silence between messages (milliseconds)", 0, 2000)
-                    .build(ui, &mut self.tts.settings.silence_between_messages)
-                {
+                if ui.slider(
+                    "TTS silence between messages (milliseconds)",
+                    0,
+                    2000,
+                    &mut self.tts.settings.silence_between_messages,
+                ) {
                     let _ = self.tts.update_settings();
                 }
 

--- a/src/plugin/state.rs
+++ b/src/plugin/state.rs
@@ -1,5 +1,22 @@
 use std::sync::{Arc, Mutex};
 
+use log::error;
+
+/// RAII guard that resets the `refreshing` flag to false when dropped.
+/// This ensures the flag is cleared even on panic or early return.
+struct RefreshingGuard {
+    flag: Arc<Mutex<bool>>,
+}
+
+impl Drop for RefreshingGuard {
+    fn drop(&mut self) {
+        match self.flag.lock() {
+            Ok(mut refreshing) => *refreshing = false,
+            Err(mut poisoned) => **poisoned.get_mut() = false,
+        }
+    }
+}
+
 #[derive(Debug)]
 pub enum ExtrasState {
     Loaded,
@@ -63,16 +80,25 @@ impl UiState {
         }
 
         std::thread::spawn(move || {
-            use rodio::cpal::traits::{DeviceTrait, HostTrait};
-            let host = rodio::cpal::default_host();
-            if let Ok(devices) = host.output_devices() {
-                let mut new_devices: Vec<String> = devices.filter_map(|d| d.name().ok()).collect();
-                new_devices.sort();
-                let mut devices = devices_mutex.lock().unwrap();
-                *devices = new_devices;
+            // Drop guard ensures `refreshing` is reset to false even if cpal panics
+            // or we return early, preventing the UI from being stuck on "Refreshing...".
+            let _guard = RefreshingGuard { flag: refreshing };
+
+            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                use rodio::cpal::traits::{DeviceTrait, HostTrait};
+                let host = rodio::cpal::default_host();
+                if let Ok(devices) = host.output_devices() {
+                    let mut new_devices: Vec<String> =
+                        devices.filter_map(|d| d.name().ok()).collect();
+                    new_devices.sort();
+                    let mut devices = devices_mutex.lock().unwrap();
+                    *devices = new_devices;
+                }
+            }));
+
+            if let Err(err) = result {
+                error!("panic while refreshing audio devices: {:?}", err);
             }
-            let mut refreshing = refreshing.lock().unwrap();
-            *refreshing = false;
         });
     }
 }


### PR DESCRIPTION
## Summary
- Bumps \`arcdps\` / \`arc_util\` to forks targeting imgui 1.92.7 (arcdps 2026-04-18 build)
- Rewrites UI against the imgui-rs 1.92 API (ChildWindow/Selectable/Slider/ColorEdit migrations, ImFont_CalcWordWrapPosition, core::ffi::c_char)
- Adds panic-safe RAII guard around the audio device refresh thread
- Adds \`igDebugCheckVersionAndDataLayout\` + version log at plugin init
- Bumps version to 0.7.0