### PR TITLE
fix: exit db worker threads cleanly on shutdown

### DIFF
--- a/src/db/insert.rs
+++ b/src/db/insert.rs
@@ -144,13 +144,16 @@ impl ChatDatabase {
     ) -> anyhow::Result<()> {
         let connection = pool.get().context("failed to get database connection")?;
         loop {
-            let event = recv_chan.recv();
-            if let Ok(insert) = event {
-                match insert {
-                    DbInsert::ChatMessage(message) => {
-                        let mut statement = connection
-                            .prepare_cached(
-                                "INSERT INTO messages (
+            let insert = match recv_chan.recv() {
+                Ok(insert) => insert,
+                // sender dropped — shutdown, exit cleanly
+                Err(_) => return Ok(()),
+            };
+            match insert {
+                DbInsert::ChatMessage(message) => {
+                    let mut statement = connection
+                        .prepare_cached(
+                            "INSERT INTO messages (
                                             channel_id,
                                             channel_type,
                                             subgroup,
@@ -161,24 +164,24 @@ impl ChatDatabase {
                                             text,
                                             game_start
                                      ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
-                            )
-                            .context("failed to prepare message insert statement")?;
-                        statement
-                            .execute(params![
-                                message.channel_id,
-                                message.channel_type.to_string(),
-                                message.subgroup,
-                                message.flags.contains(SquadMessageFlags::IS_BROADCAST),
-                                message.timestamp,
-                                message.account_name,
-                                message.character_name,
-                                message.text,
-                                game_start
-                            ])
-                            .context("failed to insert message")?;
-                    }
-                    DbInsert::AddNote(note) => {
-                        let mut statement = connection
+                        )
+                        .context("failed to prepare message insert statement")?;
+                    statement
+                        .execute(params![
+                            message.channel_id,
+                            message.channel_type.to_string(),
+                            message.subgroup,
+                            message.flags.contains(SquadMessageFlags::IS_BROADCAST),
+                            message.timestamp,
+                            message.account_name,
+                            message.character_name,
+                            message.text,
+                            game_start
+                        ])
+                        .context("failed to insert message")?;
+                }
+                DbInsert::AddNote(note) => {
+                    let mut statement = connection
                             .prepare_cached(
                                 "INSERT INTO notes (
                                             account_name,
@@ -189,41 +192,38 @@ impl ChatDatabase {
                                      ON CONFLICT (account_name) DO UPDATE SET note_updated=?2, note=?3",
                             )
                             .context("failed to prepare note insert statement")?;
-                        statement
-                            .execute(params![
-                                note.account_name,
-                                note.cur_time.to_string(),
-                                note.note
-                            ])
-                            .context("failed to insert note")?;
-                    }
-                    DbInsert::ColorNote(note) => {
-                        let mut statement = connection
+                    statement
+                        .execute(params![
+                            note.account_name,
+                            note.cur_time.to_string(),
+                            note.note
+                        ])
+                        .context("failed to insert note")?;
+                }
+                DbInsert::ColorNote(note) => {
+                    let mut statement = connection
                             .prepare_cached(
                                 "UPDATE notes SET color1=?1, color2=?2, color3=?3 WHERE account_name=?4",
                             )
                             .context("failed to prepare note color update statement")?;
-                        if let Some(color) = note.color {
-                            statement
-                                .execute(params![color[0], color[1], color[2], note.account_name,])
-                                .context("failed to update note color")?;
-                        } else {
-                            statement
-                                .execute(params![&Null, &Null, &Null, note.account_name,])
-                                .context("failed to update note color")?;
-                        }
-                    }
-                    DbInsert::DeleteNote(account_name) => {
-                        let mut statement = connection
-                            .prepare_cached("DELETE FROM notes WHERE account_name=?1")
-                            .context("failed to prepare delete note statement")?;
+                    if let Some(color) = note.color {
                         statement
-                            .execute(params![account_name,])
-                            .context("failed to delete note")?;
+                            .execute(params![color[0], color[1], color[2], note.account_name,])
+                            .context("failed to update note color")?;
+                    } else {
+                        statement
+                            .execute(params![&Null, &Null, &Null, note.account_name,])
+                            .context("failed to update note color")?;
                     }
                 }
-            } else if let Err(err) = event {
-                return Err(anyhow::Error::new(err).context("failed to receive insert event"));
+                DbInsert::DeleteNote(account_name) => {
+                    let mut statement = connection
+                        .prepare_cached("DELETE FROM notes WHERE account_name=?1")
+                        .context("failed to prepare delete note statement")?;
+                    statement
+                        .execute(params![account_name,])
+                        .context("failed to delete note")?;
+                }
             }
         }
     }

--- a/src/db/query.rs
+++ b/src/db/query.rs
@@ -85,66 +85,66 @@ impl ChatDatabase {
     ) -> anyhow::Result<()> {
         let connection = pool.get().context("failed to get database connection")?;
         loop {
-            let event = recv_chan.recv();
-            if let Ok(insert) = event {
-                match insert {
-                    DbQuery::Note(account_name) => {
-                        let mut statement = connection
+            let query = match recv_chan.recv() {
+                Ok(query) => query,
+                // sender dropped — shutdown, exit cleanly
+                Err(_) => return Ok(()),
+            };
+            match query {
+                DbQuery::Note(account_name) => {
+                    let mut statement = connection
                             .prepare_cached(
                                 "SELECT account_name, note, note_added, note_updated, color1, color2, color3 FROM notes
                                 WHERE account_name=?1 LIMIT 1",
                             )
                             .context("failed to prepare statement")?;
-                        let note_iter = statement
-                            .query_map(params![account_name], |row| {
-                                let color1: Option<f32> = row.get(4)?;
-                                let color2: Option<f32> = row.get(5)?;
-                                let color3: Option<f32> = row.get(6)?;
-                                #[allow(clippy::unnecessary_unwrap)]
-                                let color =
-                                    if color1.is_none() || color2.is_none() || color3.is_none() {
-                                        None
-                                    } else {
-                                        Some([color1.unwrap(), color2.unwrap(), color3.unwrap()])
-                                    };
-                                Ok(Note {
-                                    account_name: row.get(0)?,
-                                    note: row.get(1)?,
-                                    note_added: row.get(2)?,
-                                    note_updated: row.get(3)?,
-                                    color,
-                                })
+                    let note_iter = statement
+                        .query_map(params![account_name], |row| {
+                            let color1: Option<f32> = row.get(4)?;
+                            let color2: Option<f32> = row.get(5)?;
+                            let color3: Option<f32> = row.get(6)?;
+                            #[allow(clippy::unnecessary_unwrap)]
+                            let color = if color1.is_none() || color2.is_none() || color3.is_none()
+                            {
+                                None
+                            } else {
+                                Some([color1.unwrap(), color2.unwrap(), color3.unwrap()])
+                            };
+                            Ok(Note {
+                                account_name: row.get(0)?,
+                                note: row.get(1)?,
+                                note_added: row.get(2)?,
+                                note_updated: row.get(3)?,
+                                color,
                             })
-                            .context("failed to query note")?;
-                        let mut found = false;
-                        for note in note_iter {
-                            found = true;
-                            match note {
-                                Ok(note) => {
-                                    note_cache.lock().unwrap().insert(
-                                        account_name.to_owned(),
-                                        QueriedNote::Success(note),
-                                    );
-                                }
-                                Err(err) => {
-                                    error!("failed to query note: {:#}", err);
-                                    note_cache
-                                        .lock()
-                                        .unwrap()
-                                        .insert(account_name.to_owned(), QueriedNote::Error);
-                                }
+                        })
+                        .context("failed to query note")?;
+                    let mut found = false;
+                    for note in note_iter {
+                        found = true;
+                        match note {
+                            Ok(note) => {
+                                note_cache
+                                    .lock()
+                                    .unwrap()
+                                    .insert(account_name.to_owned(), QueriedNote::Success(note));
+                            }
+                            Err(err) => {
+                                error!("failed to query note: {:#}", err);
+                                note_cache
+                                    .lock()
+                                    .unwrap()
+                                    .insert(account_name.to_owned(), QueriedNote::Error);
                             }
                         }
-                        if !found {
-                            note_cache
-                                .lock()
-                                .unwrap()
-                                .insert(account_name.to_owned(), QueriedNote::NotFound);
-                        }
+                    }
+                    if !found {
+                        note_cache
+                            .lock()
+                            .unwrap()
+                            .insert(account_name.to_owned(), QueriedNote::NotFound);
                     }
                 }
-            } else if let Err(err) = event {
-                return Err(anyhow::Error::new(err).context("failed to receive query event"));
             }
         }
     }

--- a/src/logui/buffer.rs
+++ b/src/logui/buffer.rs
@@ -129,10 +129,9 @@ impl LogPart {
     }
 
     pub fn get_text(&self, display_hover: bool) -> String {
-        if display_hover || self.hover.is_none() {
-            self.text.clone()
-        } else {
-            format!("{} ({})", self.text, self.hover.as_ref().unwrap())
+        match &self.hover {
+            Some(hover) if !display_hover => format!("{} ({})", self.text, hover),
+            _ => self.text.clone(),
         }
     }
 


### PR DESCRIPTION
Dropping the insert/query channel senders during shutdown caused the worker threads to log 'receiving on a closed channel' errors. Treat a closed channel as a normal shutdown signal and return Ok(()).