### PR TITLE
fix: avoid empty ID in account note popup

### DIFF
--- a/src/logui/ui.rs
+++ b/src/logui/ui.rs
@@ -233,7 +233,7 @@ impl LogUi {
                     QueriedNote::Pending => true,
                 };
                 if ui
-                    .input_text("", &mut note_text)
+                    .input_text("##note", &mut note_text)
                     .read_only(read_only)
                     .build()
                     && ui.is_item_edited()


### PR DESCRIPTION
imgui 1.92 promoted empty widget IDs to a fatal assertion. The note input_text in the right-click context menu used "" as its label, which hashes to the parent window ID and triggered the new check, crashing the game on right-click in the account list.