### PR TITLE
feat: add GitHub-based DLL updater

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "arcdps-chat-log"
-version = "0.1.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "arc_util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "arcdps-chat-log"
-version = "0.7.0"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "arc_util",
@@ -105,6 +105,7 @@ dependencies = [
  "chrono",
  "itertools 0.14.0",
  "log",
+ "minreq",
  "once_cell",
  "r2d2",
  "r2d2_sqlite",
@@ -552,6 +553,17 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
@@ -808,6 +820,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+]
+
+[[package]]
+name = "minreq"
+version = "2.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05015102dad0f7d61691ca347e9d9d9006685a64aefb3d79eecf62665de2153d"
+dependencies = [
+ "rustls",
+ "rustls-webpki",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1251,7 +1274,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1297,6 +1320,20 @@ name = "regex-syntax"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "rodio"
@@ -1357,6 +1394,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1385,6 +1444,16 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "semver"
@@ -1834,12 +1903,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "uuid"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.4",
  "js-sys",
  "rand",
  "wasm-bindgen",
@@ -1880,6 +1955,12 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
@@ -1957,6 +2038,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "winapi"
@@ -2208,6 +2295,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ bitflags = "2.10"
 chrono = { version = "0.4", features = ["serde"] }
 itertools = "0.14"
 log = { version = "0.4", features = ["max_level_trace", "release_max_level_info"] }
+minreq = { version = "2.13", features = ["https-rustls"] }
 once_cell = "1.21"
 r2d2 = "0.8"
 r2d2_sqlite = "0.31"
@@ -31,7 +32,7 @@ serde_json = "1.0"
 simple-error = "0.3"
 tts = { git = "https://github.com/cheahjs/tts-rs", branch = "master" }
 winapi = { version = "0.3", features = ["consoleapi", "dbghelp", "memoryapi", "psapi", "handleapi", "processthreadsapi"] }
-windows = { version = "0.59", features = ["System"] }
+windows = { version = "0.59", features = ["System", "Win32_Foundation", "Win32_System_LibraryLoader"] }
 
 [build-dependencies.windows_exe_info]
 version = "0.4.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ mod panic_handler;
 mod plugin;
 mod tracking;
 mod tts;
+mod update;
 
 use arcdps::extras::{ExtrasAddonInfo, Message, UserInfoIter};
 use arcdps::imgui::Ui;

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -20,6 +20,7 @@ use crate::{
     plugin::state::{MumbleLinkState, NotificationsState, TtsState},
     tracking::Tracker,
     tts::TextToSpeech,
+    update::{self, UpdateState},
 };
 
 use self::state::UiState;
@@ -37,6 +38,7 @@ pub struct Plugin {
     chat_database: Option<Arc<Mutex<ChatDatabase>>>,
     tts: TextToSpeech,
     tracker: Tracker,
+    pub update_state: UpdateState,
 }
 
 impl Plugin {
@@ -58,6 +60,10 @@ impl Plugin {
             chat_database: None,
             tts: TextToSpeech::new(),
             tracker: Tracker::new(),
+            update_state: UpdateState::new(
+                Some(update::get_current_version()),
+                update::get_dll_path().unwrap_or_default(),
+            ),
         }
     }
 
@@ -69,6 +75,16 @@ impl Plugin {
         settings.load_component(&mut self.log_ui);
         settings.load_component(&mut self.notifications);
         settings.load_component(&mut self.tts);
+        settings.load_component(&mut self.update_state);
+
+        // Clean up leftover update files from a previous run, then (if enabled) check for a new version.
+        if !self.update_state.install_path.as_os_str().is_empty() {
+            update::clear_old_files(&self.update_state.install_path);
+        }
+        if self.update_state.settings.check_enabled {
+            let include_prereleases = self.update_state.settings.include_prereleases;
+            update::check_for_update(&mut self.update_state, include_prereleases);
+        }
 
         self.log_ui.buffer.buffer_max_size = self.log_ui.settings.log_buffer as usize;
 
@@ -116,6 +132,7 @@ impl Plugin {
     }
 
     pub fn release(&mut self) {
+        self.update_state.finish_pending_tasks();
         if let Some(chat_database) = &self.chat_database {
             chat_database.lock().unwrap().release();
         }
@@ -123,6 +140,7 @@ impl Plugin {
         settings.store_component(&self.log_ui);
         settings.store_component(&self.notifications);
         settings.store_component(&self.tts);
+        settings.store_component(&self.update_state);
         settings.save_file();
     }
 }

--- a/src/plugin/settings.rs
+++ b/src/plugin/settings.rs
@@ -373,9 +373,7 @@ impl Plugin {
                     &mut self.update_state.settings.include_prereleases,
                 );
                 if ui.is_item_hovered() {
-                    ui.tooltip_text(
-                        "Consider prerelease (beta) builds when checking for updates.",
-                    );
+                    ui.tooltip_text("Consider prerelease (beta) builds when checking for updates.");
                 }
 
                 ui.spacing();

--- a/src/plugin/settings.rs
+++ b/src/plugin/settings.rs
@@ -363,6 +363,36 @@ impl Plugin {
                         .play("This is some sample text being played with text to speech");
                 }
             }
+            if let Some(_tab) = ui.tab_item("Updates") {
+                ui.checkbox(
+                    "Check for updates on startup",
+                    &mut self.update_state.settings.check_enabled,
+                );
+                ui.checkbox(
+                    "Include prereleases",
+                    &mut self.update_state.settings.include_prereleases,
+                );
+                if ui.is_item_hovered() {
+                    ui.tooltip_text(
+                        "Consider prerelease (beta) builds when checking for updates.",
+                    );
+                }
+
+                ui.spacing();
+                if ui.button("Check for updates now") {
+                    let include_prereleases = self.update_state.settings.include_prereleases;
+                    // Reset state so the window will surface again.
+                    self.update_state
+                        .set_status(crate::update::UpdateStatus::Unknown);
+                    crate::update::check_for_update(&mut self.update_state, include_prereleases);
+                }
+
+                ui.group(|| {
+                    ui.text("Current version:");
+                    ui.same_line();
+                    ui.text_colored(grey, super::VERSION);
+                });
+            }
         }
     }
 

--- a/src/plugin/ui.rs
+++ b/src/plugin/ui.rs
@@ -1,10 +1,12 @@
 use arc_util::ui::{Component, Hideable, Ui};
 
 use super::Plugin;
+use crate::update;
 
 impl Plugin {
     pub fn render_windows(&mut self, ui: &Ui, _not_loading: bool) {
         self.log_ui.render(ui, &self.tracker);
+        update::draw_update_window(ui, &mut self.update_state);
     }
 
     /// Handles a key event.

--- a/src/update.rs
+++ b/src/update.rs
@@ -230,6 +230,16 @@ pub fn check_for_update(state: &mut UpdateState, include_prereleases: bool) {
             }
         };
 
+        if !(200..300).contains(&response.status_code) {
+            error!(
+                "release lookup returned HTTP {} {}: {}",
+                response.status_code,
+                response.reason_phrase,
+                response.as_str().unwrap_or("<non-utf8 body>")
+            );
+            return;
+        }
+
         let body = match response.as_str() {
             Ok(s) => s,
             Err(e) => {
@@ -352,13 +362,25 @@ pub fn perform_update(state: &mut UpdateState) {
             }
         };
 
+        // GitHub asset URLs follow a redirect to the CDN; minreq follows it transparently
+        // but we still need to verify we got a 2xx so we don't write an error page over the DLL.
+        if !(200..300).contains(&response.status_code) {
+            let msg = format!(
+                "download returned HTTP {} {}",
+                response.status_code, response.reason_phrase
+            );
+            error!("{}", msg);
+            *status.lock().unwrap() = UpdateStatus::UpdateError;
+            *error_message.lock().unwrap() = Some(msg);
+            return;
+        }
+
         let mut file = match fs::File::create(&tmp_path) {
             Ok(f) => f,
             Err(e) => {
                 error!("failed to create temp file: {}", e);
                 *status.lock().unwrap() = UpdateStatus::UpdateError;
-                *error_message.lock().unwrap() =
-                    Some(format!("failed to create temp file: {}", e));
+                *error_message.lock().unwrap() = Some(format!("failed to create temp file: {}", e));
                 return;
             }
         };

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,0 +1,498 @@
+use arc_util::settings::HasSettings;
+use arcdps::imgui::{Condition, StyleColor, Ui};
+use log::*;
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::thread::{self, JoinHandle};
+use windows::Win32::System::LibraryLoader::GetModuleFileNameW;
+
+const GITHUB_REPO: &str = "cheahjs/arcdps-chat-log";
+const RELEASES_URL: &str = "https://github.com/cheahjs/arcdps-chat-log/releases/latest";
+const USER_AGENT: &str = "arcdps-chat-log";
+
+/// Version represented as [major, minor, patch, build]
+pub type Version = [u16; 4];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UpdateStatus {
+    Unknown,
+    UpdateAvailable,
+    Dismissed,
+    UpdateInProgress,
+    UpdateSuccessful,
+    UpdateError,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct UpdateSettings {
+    /// Whether to check for updates at all on startup.
+    pub check_enabled: bool,
+    /// Whether the update check should consider prereleases.
+    pub include_prereleases: bool,
+}
+
+impl UpdateSettings {
+    pub fn new() -> Self {
+        Self {
+            check_enabled: true,
+            include_prereleases: false,
+        }
+    }
+}
+
+impl Default for UpdateSettings {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Debug)]
+pub struct UpdateState {
+    pub current_version: Option<Version>,
+    pub install_path: PathBuf,
+    pub settings: UpdateSettings,
+    status: Arc<Mutex<UpdateStatus>>,
+    pub new_version: Arc<Mutex<Option<Version>>>,
+    pub download_url: Arc<Mutex<Option<String>>>,
+    pub error_message: Arc<Mutex<Option<String>>>,
+    tasks: Vec<JoinHandle<()>>,
+}
+
+impl HasSettings for UpdateState {
+    type Settings = UpdateSettings;
+
+    const SETTINGS_ID: &'static str = "update";
+
+    fn current_settings(&self) -> Self::Settings {
+        self.settings.clone()
+    }
+
+    fn load_settings(&mut self, loaded: Self::Settings) {
+        self.settings = loaded;
+    }
+}
+
+impl UpdateState {
+    pub fn new(current_version: Option<Version>, install_path: PathBuf) -> Self {
+        Self {
+            current_version,
+            install_path,
+            settings: UpdateSettings::new(),
+            status: Arc::new(Mutex::new(UpdateStatus::Unknown)),
+            new_version: Arc::new(Mutex::new(None)),
+            download_url: Arc::new(Mutex::new(None)),
+            error_message: Arc::new(Mutex::new(None)),
+            tasks: Vec::new(),
+        }
+    }
+
+    pub fn status(&self) -> UpdateStatus {
+        *self.status.lock().unwrap()
+    }
+
+    pub fn set_status(&self, status: UpdateStatus) {
+        *self.status.lock().unwrap() = status;
+    }
+
+    pub fn finish_pending_tasks(&mut self) {
+        for task in self.tasks.drain(..) {
+            if let Err(e) = task.join() {
+                error!("error joining update task: {:?}", e);
+            }
+        }
+    }
+}
+
+pub fn get_current_version() -> Version {
+    parse_version(env!("CARGO_PKG_VERSION")).unwrap_or([0, 0, 0, 0])
+}
+
+/// Get the path to the current DLL by querying the module containing this function.
+pub fn get_dll_path() -> Option<PathBuf> {
+    use windows::Win32::Foundation::HMODULE;
+    use windows::Win32::System::LibraryLoader::{
+        GetModuleHandleExW, GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS,
+        GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+    };
+
+    unsafe {
+        let mut module: HMODULE = HMODULE::default();
+        let self_addr = get_dll_path as *const ();
+
+        if GetModuleHandleExW(
+            GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+            windows::core::PCWSTR::from_raw(self_addr as *const u16),
+            &mut module,
+        )
+        .is_err()
+        {
+            error!("GetModuleHandleExW failed");
+            return None;
+        }
+
+        let mut path_buffer = [0u16; 260];
+        let path_len = GetModuleFileNameW(Some(module), &mut path_buffer);
+        if path_len == 0 {
+            error!("GetModuleFileNameW failed");
+            return None;
+        }
+
+        let path_str = String::from_utf16_lossy(&path_buffer[..path_len as usize]);
+        Some(PathBuf::from(path_str))
+    }
+}
+
+/// Clear leftover update files from a previous run.
+pub fn clear_old_files(dll_path: &Path) {
+    for ext in ["dll.tmp", "dll.old"] {
+        let p = dll_path.with_extension(ext);
+        if let Err(e) = fs::remove_file(&p) {
+            if e.kind() != std::io::ErrorKind::NotFound {
+                warn!("failed to remove {}: {}", p.display(), e);
+            }
+        }
+    }
+}
+
+pub fn is_newer(repo_version: &Version, current_version: &Version) -> bool {
+    (current_version[0], current_version[1], current_version[2])
+        < (repo_version[0], repo_version[1], repo_version[2])
+}
+
+pub fn version_to_string(version: &Version) -> String {
+    format!("{}.{}.{}", version[0], version[1], version[2])
+}
+
+pub fn parse_version(tag: &str) -> Option<Version> {
+    let tag = tag.strip_prefix('v').unwrap_or(tag);
+    let parts: Vec<&str> = tag.split('.').collect();
+    if parts.len() < 3 {
+        return None;
+    }
+    let parse_part = |s: &str| -> Option<u16> {
+        let digits: String = s.chars().take_while(|c| c.is_ascii_digit()).collect();
+        digits.parse().ok()
+    };
+    Some([
+        parse_part(parts[0])?,
+        parse_part(parts[1])?,
+        parse_part(parts[2])?,
+        0,
+    ])
+}
+
+#[derive(Debug, Deserialize)]
+struct GitHubAsset {
+    name: String,
+    browser_download_url: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitHubRelease {
+    tag_name: String,
+    assets: Vec<GitHubAsset>,
+    #[serde(default)]
+    #[allow(dead_code)]
+    prerelease: bool,
+}
+
+pub fn check_for_update(state: &mut UpdateState, include_prereleases: bool) {
+    let status = Arc::clone(&state.status);
+    let new_version = Arc::clone(&state.new_version);
+    let download_url = Arc::clone(&state.download_url);
+    let current_version = state.current_version;
+
+    let handle = thread::spawn(move || {
+        let url = if include_prereleases {
+            format!("https://api.github.com/repos/{}/releases", GITHUB_REPO)
+        } else {
+            format!(
+                "https://api.github.com/repos/{}/releases/latest",
+                GITHUB_REPO
+            )
+        };
+
+        info!("checking for updates at {}", url);
+
+        let response = match minreq::get(&url)
+            .with_header("User-Agent", USER_AGENT)
+            .with_header("Accept", "application/vnd.github.v3+json")
+            .send()
+        {
+            Ok(resp) => resp,
+            Err(e) => {
+                error!("failed to fetch releases: {}", e);
+                return;
+            }
+        };
+
+        let body = match response.as_str() {
+            Ok(s) => s,
+            Err(e) => {
+                error!("failed to read release response body: {}", e);
+                return;
+            }
+        };
+
+        let release: GitHubRelease = if include_prereleases {
+            let releases: Vec<GitHubRelease> = match serde_json::from_str(body) {
+                Ok(r) => r,
+                Err(e) => {
+                    error!("failed to parse releases JSON: {}", e);
+                    return;
+                }
+            };
+            match releases
+                .into_iter()
+                .find(|r| r.assets.iter().any(|a| a.name.ends_with(".dll")))
+            {
+                Some(r) => r,
+                None => {
+                    error!("no releases with .dll assets found");
+                    return;
+                }
+            }
+        } else {
+            match serde_json::from_str(body) {
+                Ok(r) => r,
+                Err(e) => {
+                    error!("failed to parse release JSON: {}", e);
+                    return;
+                }
+            }
+        };
+
+        let release_version = match parse_version(&release.tag_name) {
+            Some(v) => v,
+            None => {
+                error!("failed to parse version from tag: {}", release.tag_name);
+                return;
+            }
+        };
+
+        if let Some(current) = current_version {
+            if !is_newer(&release_version, &current) {
+                info!(
+                    "current version {} is up to date (latest: {})",
+                    version_to_string(&current),
+                    version_to_string(&release_version)
+                );
+                return;
+            }
+        }
+
+        let dll_url = match release
+            .assets
+            .iter()
+            .find(|a| a.name.ends_with(".dll"))
+            .map(|a| a.browser_download_url.clone())
+        {
+            Some(u) => u,
+            None => {
+                error!("no .dll asset found in release");
+                return;
+            }
+        };
+
+        info!(
+            "update available: {} -> {} ({})",
+            current_version.map_or("unknown".to_string(), |v| version_to_string(&v)),
+            version_to_string(&release_version),
+            dll_url
+        );
+
+        *new_version.lock().unwrap() = Some(release_version);
+        *download_url.lock().unwrap() = Some(dll_url);
+        *status.lock().unwrap() = UpdateStatus::UpdateAvailable;
+    });
+
+    state.tasks.push(handle);
+}
+
+pub fn perform_update(state: &mut UpdateState) {
+    if state.status() != UpdateStatus::UpdateAvailable {
+        warn!("cannot perform update: status is {:?}", state.status());
+        return;
+    }
+
+    state.set_status(UpdateStatus::UpdateInProgress);
+
+    let install_path = state.install_path.clone();
+    let download_url = state.download_url.lock().unwrap().clone();
+    let status = Arc::clone(&state.status);
+    let error_message = Arc::clone(&state.error_message);
+
+    let Some(url) = download_url else {
+        error!("no download URL available");
+        *status.lock().unwrap() = UpdateStatus::UpdateError;
+        *error_message.lock().unwrap() = Some("no download URL available".to_string());
+        return;
+    };
+
+    let handle = thread::spawn(move || {
+        let tmp_path = install_path.with_extension("dll.tmp");
+        let old_path = install_path.with_extension("dll.old");
+
+        info!("downloading update from {}", url);
+
+        let response = match minreq::get(&url)
+            .with_header("User-Agent", USER_AGENT)
+            .send()
+        {
+            Ok(resp) => resp,
+            Err(e) => {
+                error!("failed to download update: {}", e);
+                *status.lock().unwrap() = UpdateStatus::UpdateError;
+                *error_message.lock().unwrap() = Some(format!("download failed: {}", e));
+                return;
+            }
+        };
+
+        let mut file = match fs::File::create(&tmp_path) {
+            Ok(f) => f,
+            Err(e) => {
+                error!("failed to create temp file: {}", e);
+                *status.lock().unwrap() = UpdateStatus::UpdateError;
+                *error_message.lock().unwrap() =
+                    Some(format!("failed to create temp file: {}", e));
+                return;
+            }
+        };
+
+        if let Err(e) = file.write_all(response.as_bytes()) {
+            error!("failed to write to temp file: {}", e);
+            *status.lock().unwrap() = UpdateStatus::UpdateError;
+            *error_message.lock().unwrap() = Some(format!("failed to write temp file: {}", e));
+            return;
+        }
+        drop(file);
+
+        if let Err(e) = fs::rename(&install_path, &old_path) {
+            error!(
+                "failed to rename {} to {}: {}",
+                install_path.display(),
+                old_path.display(),
+                e
+            );
+            *status.lock().unwrap() = UpdateStatus::UpdateError;
+            *error_message.lock().unwrap() = Some(format!("failed to backup current file: {}", e));
+            return;
+        }
+
+        if let Err(e) = fs::rename(&tmp_path, &install_path) {
+            error!(
+                "failed to rename {} to {}: {}",
+                tmp_path.display(),
+                install_path.display(),
+                e
+            );
+            let _ = fs::rename(&old_path, &install_path);
+            *status.lock().unwrap() = UpdateStatus::UpdateError;
+            *error_message.lock().unwrap() = Some(format!("failed to install new file: {}", e));
+            return;
+        }
+
+        info!("update completed successfully");
+        *status.lock().unwrap() = UpdateStatus::UpdateSuccessful;
+    });
+
+    state.tasks.push(handle);
+}
+
+pub fn draw_update_window(ui: &Ui, state: &mut UpdateState) {
+    let status = state.status();
+
+    if status == UpdateStatus::Unknown || status == UpdateStatus::Dismissed {
+        return;
+    }
+
+    let mut open = true;
+
+    ui.window("Chat Log Update")
+        .opened(&mut open)
+        .collapsible(false)
+        .always_auto_resize(true)
+        .size([350.0, 0.0], Condition::FirstUseEver)
+        .build(|| {
+            if let Some(current) = state.current_version {
+                let _red = ui.push_style_color(StyleColor::Text, [1.0, 0.3, 0.3, 1.0]);
+                ui.text("A new version of Chat Log is available!");
+                ui.text(format!("Current version: {}", version_to_string(&current)));
+            }
+
+            if let Some(new_ver) = *state.new_version.lock().unwrap() {
+                let _green = ui.push_style_color(StyleColor::Text, [0.3, 1.0, 0.3, 1.0]);
+                ui.text(format!("New version: {}", version_to_string(&new_ver)));
+            }
+
+            ui.separator();
+
+            if ui.button("Open Releases Page") {
+                let _ = std::process::Command::new("cmd")
+                    .args(["/C", "start", RELEASES_URL])
+                    .spawn();
+            }
+
+            match status {
+                UpdateStatus::UpdateAvailable => {
+                    ui.same_line();
+                    if ui.button("Install Update") {
+                        perform_update(state);
+                    }
+                }
+                UpdateStatus::UpdateInProgress => {
+                    ui.text("Downloading update...");
+                }
+                UpdateStatus::UpdateSuccessful => {
+                    let _green = ui.push_style_color(StyleColor::Text, [0.3, 1.0, 0.3, 1.0]);
+                    ui.text("Update successful! Restart the game to apply.");
+                }
+                UpdateStatus::UpdateError => {
+                    let _red = ui.push_style_color(StyleColor::Text, [1.0, 0.3, 0.3, 1.0]);
+                    if let Some(ref msg) = *state.error_message.lock().unwrap() {
+                        ui.text(format!("Update failed: {}", msg));
+                    } else {
+                        ui.text("Update failed!");
+                    }
+                }
+                _ => {}
+            }
+        });
+
+    if !open && status != UpdateStatus::UpdateInProgress {
+        state.set_status(UpdateStatus::Dismissed);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_version() {
+        assert_eq!(parse_version("1.2.3"), Some([1, 2, 3, 0]));
+        assert_eq!(parse_version("v1.2.3"), Some([1, 2, 3, 0]));
+        assert_eq!(parse_version("v10.20.30"), Some([10, 20, 30, 0]));
+        assert_eq!(parse_version("1.2"), None);
+        assert_eq!(parse_version("1.2.3-beta"), Some([1, 2, 3, 0]));
+    }
+
+    #[test]
+    fn test_is_newer() {
+        assert!(is_newer(&[2, 0, 0, 0], &[1, 0, 0, 0]));
+        assert!(is_newer(&[1, 1, 0, 0], &[1, 0, 0, 0]));
+        assert!(is_newer(&[1, 0, 1, 0], &[1, 0, 0, 0]));
+        assert!(!is_newer(&[1, 0, 0, 0], &[1, 0, 0, 0]));
+        assert!(!is_newer(&[1, 0, 0, 0], &[2, 0, 0, 0]));
+    }
+
+    #[test]
+    fn test_version_to_string() {
+        assert_eq!(version_to_string(&[1, 2, 3, 0]), "1.2.3");
+        assert_eq!(version_to_string(&[10, 20, 30, 0]), "10.20.30");
+    }
+}


### PR DESCRIPTION
Checks the latest GitHub release on plugin load and surfaces an in-game prompt to download and swap the DLL when a newer version is published. Adds an Updates settings tab with toggles for the startup check, prereleases, and a manual recheck button.